### PR TITLE
Change package paths so that they are found after running "go get"

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -5,24 +5,24 @@ import (
 )
 
 type AtemCmd struct {
-	Name string
-	Body []byte
+	Name   string
+	Body   []byte
 	Header []byte
 }
 
 func New(Name string, Body []byte) *AtemCmd {
-	return &AtemCmd{ Name: Name, Body: Body }
+	return &AtemCmd{Name: Name, Body: Body}
 }
 
 func Parse(msg []byte) *AtemCmd {
-	return &AtemCmd{ Name: string(msg[4:8]), Body: msg[8:] }
+	return &AtemCmd{Name: string(msg[4:8]), Body: msg[8:]}
 }
 
 func (ac *AtemCmd) Length() uint16 {
 	return uint16(len(ac.Body) + 8)
 }
 
-func (ac *AtemCmd) String() string  {
+func (ac *AtemCmd) String() string {
 	return fmt.Sprintf("Command:\t[%s]\t%d", ac.Name, ac.Body)
 }
 
@@ -33,7 +33,7 @@ func (ac *AtemCmd) ToBytes() []byte {
 	result = append(result, []byte{uint8(ac.Length() >> 8), uint8(ac.Length() & 0xFF)}...)
 
 	// Set header
-	result = append(result, []byte{ 0, 0 }...)
+	result = append(result, []byte{0, 0}...)
 
 	// Set cmd
 	result = append(result, []byte(ac.Name)...)

--- a/types/video_source/video_source.go
+++ b/types/video_source/video_source.go
@@ -3,8 +3,9 @@ package video_source
 import (
 	"encoding/binary"
 	"fmt"
-	"go-atem/types"
 	"strings"
+
+	"github.com/bdogan/go-atem/types"
 )
 
 var VideoSourceAvailableExtPortTypes = map[uint8]string{
@@ -25,13 +26,13 @@ var VideoSourceExtPortTypes = map[uint8]string{
 }
 
 var VideoSourcePortTypes = map[uint8]string{
-	0: "External",
-	1: "Black",
-	2: "ColorBars",
-	3: "ColorGenerator",
-	4: "MediaPlayerFill",
-	5: "MediaPlayerKey",
-	6: "SuperSource",
+	0:   "External",
+	1:   "Black",
+	2:   "ColorBars",
+	3:   "ColorGenerator",
+	4:   "MediaPlayerFill",
+	5:   "MediaPlayerKey",
+	6:   "SuperSource",
 	128: "MEOutput",
 	129: "Auxilary",
 	130: "Mask",
@@ -51,53 +52,53 @@ var MEAvailability = map[uint8]string{
 }
 
 var VideoSourceType = map[uint16]string{
-	0		: "Black",
-	1		: "Input1",
-	2		: "Input2",
-	3		: "Input3",
-	4		: "Input4",
-	5		: "Input5",
-	6		: "Input6",
-	7		: "Input7",
-	8		: "Input8",
-	9		: "Input9",
-	10		: "Input10",
-	11		: "Input11",
-	12		: "Input12",
-	13		: "Input13",
-	14		: "Input14",
-	15		: "Input15",
-	16		: "Input16",
-	17		: "Input17",
-	18		: "Input18",
-	19		: "Input19",
-	20		: "Input20",
-	1000	: "ColorBars",
-	2001	: "Color1",
-	2002	: "Color2",
-	3010	: "MediaPlayer1",
-	3011	: "MediaPlayer1Key",
-	3020	: "MediaPlayer2",
-	3021	: "MediaPlayer2Key",
-	4010	: "Key1Mask",
-	4020	: "Key2Mask",
-	4030	: "Key3Mask",
-	4040	: "Key4Mask",
-	5010	: "DSK1Mask",
-	5020	: "DSK2Mask",
-	6000	: "SuperSource",
-	7001	: "CleanFeed1",
-	7002	: "CleanFeed2",
-	8001	: "Auxilary1",
-	8002	: "Auxilary2",
-	8003	: "Auxilary3",
-	8004	: "Auxilary4",
-	8005	: "Auxilary5",
-	8006	: "Auxilary6",
-	10010	: "ME1Prog",
-	10011	: "ME1Prev",
-	10020	: "ME2Prog",
-	10021	: "ME2Prev",
+	0:     "Black",
+	1:     "Input1",
+	2:     "Input2",
+	3:     "Input3",
+	4:     "Input4",
+	5:     "Input5",
+	6:     "Input6",
+	7:     "Input7",
+	8:     "Input8",
+	9:     "Input9",
+	10:    "Input10",
+	11:    "Input11",
+	12:    "Input12",
+	13:    "Input13",
+	14:    "Input14",
+	15:    "Input15",
+	16:    "Input16",
+	17:    "Input17",
+	18:    "Input18",
+	19:    "Input19",
+	20:    "Input20",
+	1000:  "ColorBars",
+	2001:  "Color1",
+	2002:  "Color2",
+	3010:  "MediaPlayer1",
+	3011:  "MediaPlayer1Key",
+	3020:  "MediaPlayer2",
+	3021:  "MediaPlayer2Key",
+	4010:  "Key1Mask",
+	4020:  "Key2Mask",
+	4030:  "Key3Mask",
+	4040:  "Key4Mask",
+	5010:  "DSK1Mask",
+	5020:  "DSK2Mask",
+	6000:  "SuperSource",
+	7001:  "CleanFeed1",
+	7002:  "CleanFeed2",
+	8001:  "Auxilary1",
+	8002:  "Auxilary2",
+	8003:  "Auxilary3",
+	8004:  "Auxilary4",
+	8005:  "Auxilary5",
+	8006:  "Auxilary6",
+	10010: "ME1Prog",
+	10011: "ME1Prev",
+	10020: "ME2Prog",
+	10021: "ME2Prev",
 }
 
 type VideoSources struct {
@@ -106,14 +107,14 @@ type VideoSources struct {
 
 func CreateVideoSourceList() *VideoSources {
 	list := map[uint16]*VideoSource{}
-	return &VideoSources{ list: &list }
+	return &VideoSources{list: &list}
 }
 
 func (vss *VideoSources) Update(data []byte) {
 	inputIndex := binary.BigEndian.Uint16(data[0:2])
 	videoSource, exists := (*vss.list)[inputIndex]
 	if !exists {
-		videoSource = &VideoSource{ index: inputIndex }
+		videoSource = &VideoSource{index: inputIndex}
 		(*vss.list)[inputIndex] = videoSource
 	}
 	videoSource.Update(data)
@@ -138,14 +139,14 @@ func (vss *VideoSources) String() string {
 type VideoSource struct {
 	index uint16
 
-	Type string
-	LongName types.NullTerminatedString
-	ShortName types.NullTerminatedString
+	Type                       string
+	LongName                   types.NullTerminatedString
+	ShortName                  types.NullTerminatedString
 	AvailableExternalPortTypes []string
-	ExternalPortType string
-	PortType string
-	Availability []string
-	MEAvailability []string
+	ExternalPortType           string
+	PortType                   string
+	Availability               []string
+	MEAvailability             []string
 }
 
 func (vs *VideoSource) String() string {
@@ -154,13 +155,13 @@ func (vs *VideoSource) String() string {
 
 func (vs *VideoSource) Update(data []byte) {
 	vs.Type = VideoSourceType[vs.index]
-	vs.LongName = types.NullTerminatedString{ Body: data[2:22] }
-	vs.ShortName = types.NullTerminatedString{ Body: data[22:26] }
+	vs.LongName = types.NullTerminatedString{Body: data[2:22]}
+	vs.ShortName = types.NullTerminatedString{Body: data[22:26]}
 	vs.AvailableExternalPortTypes = []string{}
 
 	// Available Ext Port Types
 	for i, v := range VideoSourceAvailableExtPortTypes {
-		if data[29] & (1 << i) == (1 << i) {
+		if data[29]&(1<<i) == (1 << i) {
 			vs.AvailableExternalPortTypes = append(vs.AvailableExternalPortTypes, v)
 		}
 	}
@@ -173,14 +174,14 @@ func (vs *VideoSource) Update(data []byte) {
 
 	// Availability
 	for i, v := range Availability {
-		if data[34] & (1 << i) == (1 << i) {
+		if data[34]&(1<<i) == (1 << i) {
 			vs.Availability = append(vs.Availability, v)
 		}
 	}
 
 	// MeAvailability
 	for i, v := range MEAvailability {
-		if data[35] & (1 << i) == (1 << i) {
+		if data[35]&(1<<i) == (1 << i) {
 			vs.MEAvailability = append(vs.MEAvailability, v)
 		}
 	}


### PR DESCRIPTION
Fixes an issue where Go cannot resolve paths like "go-atem/types", etc. by specifying the full path, ex. "github.com/bdogan/go-atem/types"